### PR TITLE
chore: use causes formating

### DIFF
--- a/app/native/src/api.rs
+++ b/app/native/src/api.rs
@@ -212,9 +212,9 @@ pub async fn minecraft_login_flow(skin: StreamSink<LoginFlowEvent>) -> anyhow::R
         }
         Err(e) => {
             skin.add(LoginFlowEvent::Error(LoginFlowErrors::UnknownError(
-                e.to_string(),
+                format!("{e:#}"),
             )));
-            warn!("Failed to login minecraft account: {:#?}", e);
+            warn!("Failed to login minecraft account: {:#}", e);
         }
     }
 


### PR DESCRIPTION
/// To print causes as well using anyhow's default formatting of causes, use the
/// alternate selector "{:#}"
